### PR TITLE
M2M attr: sibling-attribute filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ACCOUNT=gaf3
 IMAGE=python-relations
 INSTALL=python:3.8.5-alpine3.12
-VERSION?=0.6.14
+VERSION?=0.6.15
 DEBUG_PORT=5678
 TTY=$(shell if tty -s; then echo "-it"; fi)
 VOLUMES=-v ${PWD}/lib:/opt/service/lib \

--- a/lib/relations/model.py
+++ b/lib/relations/model.py
@@ -415,6 +415,7 @@ class Model(ModelIdentity):
         self._children = {}
         self._sisters = {}
         self._brothers = {}
+        self._ties = []
         self._related = {}
 
         # Making things and explicit, we're going to derive a lot defaults from
@@ -813,6 +814,41 @@ class Model(ModelIdentity):
 
         return None
 
+    def _tie(self, name, remainder, value):
+        """
+        Captures a many-to-many sibling-attribute filter (e.g. bro__name="Tom") to be
+        resolved against the tie table by the source's collate_ties.
+        """
+
+        relation = self.SISTERS[name] if name in self.SISTERS else self.BROTHERS[name]
+        side = "sister" if name in self.SISTERS else "brother"
+
+        field, operator, negate = self._tie_operator(remainder)
+
+        self._ties.append((relation, side, field, operator, negate, value))
+
+    @staticmethod
+    def _tie_operator(remainder):
+        """
+        Splits a sibling-attribute path into (field path, tie set-operator, negate).
+        A trailing has/any/all (or not_ variant) is the tie operator, but only when a field
+        path precedes it; anything else (including a bare operator with no field) is part of
+        the sibling field predicate and defaults the tie operator to "has".
+
+        The tie set-operator always claims a trailing has/any/all, so a sibling's OWN set or
+        JSON field cannot take a field-level has/any/all directly (bro__tags__has="x" reads
+        as the tie's has over field "tags"). To reach the sibling's field operator, double
+        the suffix: bro__tags__has__has="x" -> field "tags__has", tie operator "has".
+        """
+
+        pieces = remainder.split("__")
+        bare = pieces[-1].split("not_", 1)[-1]
+
+        if len(pieces) > 1 and bare in ("has", "any", "all"):
+            return "__".join(pieces[:-1]), bare, pieces[-1].startswith("not_")
+
+        return remainder, "has", False
+
     def _collate(self):
         """
         Executes relatives criteria and adds to our own
@@ -942,12 +978,18 @@ class Model(ModelIdentity):
 
                 pieces = name.split('__', 1)
 
-                relation = self._relate(pieces[0])
+                if len(pieces) == 2 and (pieces[0] in self.SISTERS or pieces[0] in self.BROTHERS):
 
-                if relation is not None:
-                    relation.filter(**{pieces[1]: value})
+                    self._tie(pieces[0], pieces[1], value)
+
                 else:
-                    self._record.filter(name, value)
+
+                    relation = self._relate(pieces[0])
+
+                    if relation is not None:
+                        relation.filter(**{pieces[1]: value})
+                    else:
+                        self._record.filter(name, value)
 
         return self
 

--- a/lib/relations/model.py
+++ b/lib/relations/model.py
@@ -415,7 +415,7 @@ class Model(ModelIdentity):
         self._children = {}
         self._sisters = {}
         self._brothers = {}
-        self._ties = []
+        self._ties = {}
         self._related = {}
 
         # Making things and explicit, we're going to derive a lot defaults from
@@ -816,38 +816,12 @@ class Model(ModelIdentity):
 
     def _tie(self, name, remainder, value):
         """
-        Captures a many-to-many sibling-attribute filter (e.g. bro__name="Tom") to be
-        resolved against the tie table by the source's collate_ties.
+        Captures a many-to-many sibling-attribute filter (e.g. bro__name="Tom"). The sibling
+        criteria are grouped per relation (so bro__name="Tom", bro__id__gt=5 filter the same
+        tied brother) and resolved against the tie table by the source's collate_ties.
         """
 
-        relation = self.SISTERS[name] if name in self.SISTERS else self.BROTHERS[name]
-        side = "sister" if name in self.SISTERS else "brother"
-
-        field, operator, negate = self._tie_operator(remainder)
-
-        self._ties.append((relation, side, field, operator, negate, value))
-
-    @staticmethod
-    def _tie_operator(remainder):
-        """
-        Splits a sibling-attribute path into (field path, tie set-operator, negate).
-        A trailing has/any/all (or not_ variant) is the tie operator, but only when a field
-        path precedes it; anything else (including a bare operator with no field) is part of
-        the sibling field predicate and defaults the tie operator to "has".
-
-        The tie set-operator always claims a trailing has/any/all, so a sibling's OWN set or
-        JSON field cannot take a field-level has/any/all directly (bro__tags__has="x" reads
-        as the tie's has over field "tags"). To reach the sibling's field operator, double
-        the suffix: bro__tags__has__has="x" -> field "tags__has", tie operator "has".
-        """
-
-        pieces = remainder.split("__")
-        bare = pieces[-1].split("not_", 1)[-1]
-
-        if len(pieces) > 1 and bare in ("has", "any", "all"):
-            return "__".join(pieces[:-1]), bare, pieces[-1].startswith("not_")
-
-        return remainder, "has", False
+        self._ties.setdefault(name, {})[remainder] = value
 
     def _collate(self):
         """

--- a/lib/relations/source.py
+++ b/lib/relations/source.py
@@ -243,10 +243,55 @@ class Source:
         return set(ties[result_ref])
 
     @staticmethod
-    def collate_ties(model):
+    def attr_ids(relation, side, field, operator, value):
+        """
+        The set of model ids tied to a sibling whose field matches a predicate
+        (M2M attribute filtering, e.g. bro__name="Tom"). Resolves the sibling field
+        predicate to sibling ids, then walks the tie table to collect the tied model ids.
+        """
+
+        if side == "sister":
+            Sibling, sibling_id = relation.Sister, relation.sister_id
+            query_ref, result_ref = relation.tie_sister_ref, relation.tie_brother_ref
+        else:
+            Sibling, sibling_id = relation.Brother, relation.brother_id
+            query_ref, result_ref = relation.tie_brother_ref, relation.tie_sister_ref
+
+        def model_ids(predicate):
+            sibling_ids = Sibling.many(**predicate).retrieve()[sibling_id]
+            if not sibling_ids:
+                return set()
+            return Source.tie_ids(relation.Tie, query_ref, result_ref, "any", sibling_ids)
+
+        # "all": tied to a sibling matching every requested value, each value resolved
+        # independently and intersected (distinct attribute values, not distinct ids)
+        if operator == "all":
+            items = value if isinstance(value, (list, set, tuple)) else [value]
+            matched = None
+            for item in items:
+                ids = model_ids({field: item})
+                matched = ids if matched is None else (matched & ids)
+            return matched if matched is not None else set()
+
+        # has/any: tied to at least one sibling matching the predicate. A list of values
+        # is OR'd — tied to a sibling matching any one of them — by resolving each value as
+        # its own predicate and unioning, so it works for field operators (name__like) and
+        # nested paths (meta__role) too, mirroring tie-id has/any.
+        if isinstance(value, (list, set, tuple)):
+            matched = set()
+            for item in value:
+                matched |= model_ids({field: item})
+            return matched
+
+        return model_ids({field: value})
+
+    @staticmethod
+    def collate_ties(model): # pylint: disable=too-many-locals
         """
         Resolves tie-field set criteria (has/any/all and their not_ variants) into
-        id__in / id__not_in filters on the model, by walking the tie table.
+        id__in / id__not_in filters on the model, by walking the tie table. Handles both
+        tie-id criteria (bro_id__has=...) and sibling-attribute criteria (bro__name=...,
+        captured on model._ties).
         """
 
         # No ties here, nothing to collate
@@ -289,6 +334,21 @@ class Source:
                     include = matched if include is None else (include & matched)
 
             field.criteria = {}
+
+        # Sibling-attribute criteria (bro__name=...): resolve the sibling field predicate
+        # to sibling ids, then collect the tied model ids through the tie table.
+        for relation, side, field, operator, negate, value in model._ties:
+
+            has_criteria = True
+
+            matched = Source.attr_ids(relation, side, field, operator, value)
+
+            if negate:
+                exclude |= matched
+            else:
+                include = matched if include is None else (include & matched)
+
+        model._ties = []
 
         if not has_criteria:
             return

--- a/lib/relations/source.py
+++ b/lib/relations/source.py
@@ -243,11 +243,12 @@ class Source:
         return set(ties[result_ref])
 
     @staticmethod
-    def attr_ids(relation, side, field, operator, value):
+    def attr_ids(relation, side, criteria):
         """
-        The set of model ids tied to a sibling whose field matches a predicate
-        (M2M attribute filtering, e.g. bro__name="Tom"). Resolves the sibling field
-        predicate to sibling ids, then walks the tie table to collect the tied model ids.
+        The set of model ids tied to a sibling matching the given field criteria
+        (M2M attribute filtering, e.g. bro__name="Tom"). Resolves the sibling criteria to
+        sibling ids, then walks the tie table to collect the tied model ids. Existence
+        semantics: a model matches if it is tied to any sibling satisfying the criteria.
         """
 
         if side == "sister":
@@ -257,33 +258,12 @@ class Source:
             Sibling, sibling_id = relation.Brother, relation.brother_id
             query_ref, result_ref = relation.tie_brother_ref, relation.tie_sister_ref
 
-        def model_ids(predicate):
-            sibling_ids = Sibling.many(**predicate).retrieve()[sibling_id]
-            if not sibling_ids:
-                return set()
-            return Source.tie_ids(relation.Tie, query_ref, result_ref, "any", sibling_ids)
+        sibling_ids = Sibling.many(**criteria).retrieve()[sibling_id]
 
-        # "all": tied to a sibling matching every requested value, each value resolved
-        # independently and intersected (distinct attribute values, not distinct ids)
-        if operator == "all":
-            items = value if isinstance(value, (list, set, tuple)) else [value]
-            matched = None
-            for item in items:
-                ids = model_ids({field: item})
-                matched = ids if matched is None else (matched & ids)
-            return matched if matched is not None else set()
+        if not sibling_ids:
+            return set()
 
-        # has/any: tied to at least one sibling matching the predicate. A list of values
-        # is OR'd — tied to a sibling matching any one of them — by resolving each value as
-        # its own predicate and unioning, so it works for field operators (name__like) and
-        # nested paths (meta__role) too, mirroring tie-id has/any.
-        if isinstance(value, (list, set, tuple)):
-            matched = set()
-            for item in value:
-                matched |= model_ids({field: item})
-            return matched
-
-        return model_ids({field: value})
+        return Source.tie_ids(relation.Tie, query_ref, result_ref, "any", sibling_ids)
 
     @staticmethod
     def collate_ties(model): # pylint: disable=too-many-locals
@@ -335,20 +315,20 @@ class Source:
 
             field.criteria = {}
 
-        # Sibling-attribute criteria (bro__name=...): resolve the sibling field predicate
-        # to sibling ids, then collect the tied model ids through the tie table.
-        for relation, side, field, operator, negate, value in model._ties:
+        # Sibling-attribute criteria (bro__name=...): resolve each relation's grouped sibling
+        # criteria to sibling ids, then collect the tied model ids through the tie table.
+        for name, criteria in model._ties.items():
 
             has_criteria = True
 
-            matched = Source.attr_ids(relation, side, field, operator, value)
+            relation = model.SISTERS[name] if name in model.SISTERS else model.BROTHERS[name]
+            side = "sister" if name in model.SISTERS else "brother"
 
-            if negate:
-                exclude |= matched
-            else:
-                include = matched if include is None else (include & matched)
+            matched = Source.attr_ids(relation, side, criteria)
 
-        model._ties = []
+            include = matched if include is None else (include & matched)
+
+        model._ties = {}
 
         if not has_criteria:
             return

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="relations-dil",
-    version="0.6.14",
+    version="0.6.15",
     package_dir = {'': 'lib'},
     py_modules = [
         'relations',

--- a/test/test_relations/test_model.py
+++ b/test/test_relations/test_model.py
@@ -1423,30 +1423,12 @@ class TestModel(unittest.TestCase):
 
         self.assertEqual(test._like, "fuzzy")
 
-    def test__tie_operator(self):
-
-        # a trailing has/any/all (or not_ variant) is the tie set-operator
-        self.assertEqual(Sis._tie_operator("name"), ("name", "has", False))
-        self.assertEqual(Sis._tie_operator("name__has"), ("name", "has", False))
-        self.assertEqual(Sis._tie_operator("name__any"), ("name", "any", False))
-        self.assertEqual(Sis._tie_operator("name__all"), ("name", "all", False))
-        self.assertEqual(Sis._tie_operator("name__not_all"), ("name", "all", True))
-        # anything else stays part of the sibling field predicate, defaulting to has
-        self.assertEqual(Sis._tie_operator("name__like"), ("name__like", "has", False))
-        # a bare operator with no preceding field stays a field path (defaults to has)
-        self.assertEqual(Sis._tie_operator("has"), ("has", "has", False))
-
     def test__tie(self):
 
-        sis = Sis.many(bro__name__all=["Tom", "Dick"])
+        # sibling-attribute criteria are grouped per relation accessor
+        sis = Sis.many(bro__name="Tom", bro__id__gt=5)
 
-        relation, side, field, operator, negate, value = sis._ties[0]
-
-        self.assertEqual(side, "brother")
-        self.assertEqual(field, "name")
-        self.assertEqual(operator, "all")
-        self.assertFalse(negate)
-        self.assertEqual(value, ["Tom", "Dick"])
+        self.assertEqual(sis._ties, {"bro": {"name": "Tom", "id__gt": 5}})
 
     def test_bulk(self):
 

--- a/test/test_relations/test_model.py
+++ b/test/test_relations/test_model.py
@@ -1423,6 +1423,31 @@ class TestModel(unittest.TestCase):
 
         self.assertEqual(test._like, "fuzzy")
 
+    def test__tie_operator(self):
+
+        # a trailing has/any/all (or not_ variant) is the tie set-operator
+        self.assertEqual(Sis._tie_operator("name"), ("name", "has", False))
+        self.assertEqual(Sis._tie_operator("name__has"), ("name", "has", False))
+        self.assertEqual(Sis._tie_operator("name__any"), ("name", "any", False))
+        self.assertEqual(Sis._tie_operator("name__all"), ("name", "all", False))
+        self.assertEqual(Sis._tie_operator("name__not_all"), ("name", "all", True))
+        # anything else stays part of the sibling field predicate, defaulting to has
+        self.assertEqual(Sis._tie_operator("name__like"), ("name__like", "has", False))
+        # a bare operator with no preceding field stays a field path (defaults to has)
+        self.assertEqual(Sis._tie_operator("has"), ("has", "has", False))
+
+    def test__tie(self):
+
+        sis = Sis.many(bro__name__all=["Tom", "Dick"])
+
+        relation, side, field, operator, negate, value = sis._ties[0]
+
+        self.assertEqual(side, "brother")
+        self.assertEqual(field, "name")
+        self.assertEqual(operator, "all")
+        self.assertFalse(negate)
+        self.assertEqual(value, ["Tom", "Dick"])
+
     def test_bulk(self):
 
         models = UnitTest.bulk(4)

--- a/test/test_relations/test_source.py
+++ b/test/test_relations/test_source.py
@@ -296,11 +296,11 @@ class TestSource(unittest.TestCase):
         self.source.collate_ties(sis)
         self.assertFalse(sis._record._names["id"].criteria)
 
-        # sibling-attribute criteria captured on _ties, consumed into an id filter
+        # sibling-attribute criteria captured per relation on _ties, consumed into an id filter
         sis = Sis.many(bro__name="Tom")
-        self.assertTrue(sis._ties)
+        self.assertEqual(sis._ties, {"bro": {"name": "Tom"}})
         self.source.collate_ties(sis)
-        self.assertFalse(sis._ties)
+        self.assertEqual(sis._ties, {})
         self.assertEqual(sis._record._names["id"].criteria["in"], [1])
 
     def test_attr_ids(self):
@@ -313,16 +313,14 @@ class TestSource(unittest.TestCase):
 
         relation = Sis.BROTHERS["bro"]
 
-        # has: tied to a brother named Tom
-        self.assertEqual(self.source.attr_ids(relation, "brother", "name", "has", "Tom"), {1, 2})
-        # any: tied to a brother whose name is any of these
-        self.assertEqual(self.source.attr_ids(relation, "brother", "name", "any", ["Dick"]), {1})
-        # all: tied to a brother named Tom AND a brother named Dick
-        self.assertEqual(self.source.attr_ids(relation, "brother", "name", "all", ["Tom", "Dick"]), {1})
-        # has with a list OR's the values (tied to a brother named Tom or Dick)
-        self.assertEqual(self.source.attr_ids(relation, "brother", "name", "has", ["Tom", "Dick"]), {1, 2})
+        # tied to a brother named Tom
+        self.assertEqual(self.source.attr_ids(relation, "brother", {"name": "Tom"}), {1, 2})
+        # tied to a brother whose name is any of these (field in)
+        self.assertEqual(self.source.attr_ids(relation, "brother", {"name__in": ["Dick"]}), {1})
+        # multiple criteria filter the same sibling (a brother named Tom with Dick's id: none)
+        self.assertEqual(self.source.attr_ids(relation, "brother", {"name": "Tom", "id": dick.id}), set())
         # no such sibling
-        self.assertEqual(self.source.attr_ids(relation, "brother", "name", "has", "Ghost"), set())
+        self.assertEqual(self.source.attr_ids(relation, "brother", {"name": "Ghost"}), set())
 
     def test_retrieve_ties(self):
 

--- a/test/test_relations/test_source.py
+++ b/test/test_relations/test_source.py
@@ -296,6 +296,34 @@ class TestSource(unittest.TestCase):
         self.source.collate_ties(sis)
         self.assertFalse(sis._record._names["id"].criteria)
 
+        # sibling-attribute criteria captured on _ties, consumed into an id filter
+        sis = Sis.many(bro__name="Tom")
+        self.assertTrue(sis._ties)
+        self.source.collate_ties(sis)
+        self.assertFalse(sis._ties)
+        self.assertEqual(sis._record._names["id"].criteria["in"], [1])
+
+    def test_attr_ids(self):
+
+        tom = Bro("Tom").create()
+        dick = Bro("Dick").create()
+
+        Sis("Mary", bro_id=[tom.id, dick.id]).create()  # id 1, tied to Tom, Dick
+        Sis("Sue", bro_id=[tom.id]).create()            # id 2, tied to Tom
+
+        relation = Sis.BROTHERS["bro"]
+
+        # has: tied to a brother named Tom
+        self.assertEqual(self.source.attr_ids(relation, "brother", "name", "has", "Tom"), {1, 2})
+        # any: tied to a brother whose name is any of these
+        self.assertEqual(self.source.attr_ids(relation, "brother", "name", "any", ["Dick"]), {1})
+        # all: tied to a brother named Tom AND a brother named Dick
+        self.assertEqual(self.source.attr_ids(relation, "brother", "name", "all", ["Tom", "Dick"]), {1})
+        # has with a list OR's the values (tied to a brother named Tom or Dick)
+        self.assertEqual(self.source.attr_ids(relation, "brother", "name", "has", ["Tom", "Dick"]), {1, 2})
+        # no such sibling
+        self.assertEqual(self.source.attr_ids(relation, "brother", "name", "has", "Ghost"), set())
+
     def test_retrieve_ties(self):
 
         tom = Bro("Tom").create()

--- a/test/test_relations/test_unittest.py
+++ b/test/test_relations/test_unittest.py
@@ -861,9 +861,9 @@ class TestSource(unittest.TestCase):
 
     def test_retrieve_ties_attr(self):
 
-        # M2M attribute filtering: filter by a tied sibling's field (bro__name) rather
-        # than its id. has/any/all carry over from tie-id Select, now over the sibling's
-        # attribute values, resolved through the tie table.
+        # M2M attribute filtering: filter by a tied sibling's field (bro__name) via the tie
+        # table. Existence semantics — a model matches if it's tied to a sibling matching the
+        # criteria; the sibling's normal field operators (in/like/not_in) all apply.
 
         tom = Bro("Tom").create()
         dick = Bro("Dick").create()
@@ -873,36 +873,22 @@ class TestSource(unittest.TestCase):
         Sis("Sue", bro_id=[tom.id]).create()             # tied to Tom
         Sis("Ann", bro_id=[dick.id, harry.id]).create()  # tied to Dick, Harry
 
-        # has (the default): tied to a brother with that name
+        # tied to a brother with that name
         self.assertEqual(sorted(Sis.many(bro__name="Tom").name), ["Mary", "Sue"])
         self.assertEqual(Sis.many(bro__name="Harry").name, ["Ann"])
         self.assertEqual(len(Sis.many(bro__name="Ghost")), 0)
-        self.assertEqual(sorted(Sis.many(bro__name__has="Tom").name), ["Mary", "Sue"])
 
-        # any: tied to a brother whose name is any of these
-        self.assertEqual(sorted(Sis.many(bro__name__any=["Tom", "Harry"]).name), ["Ann", "Mary", "Sue"])
-        self.assertEqual(Sis.many(bro__name__any=["Harry"]).name, ["Ann"])
-        self.assertEqual(len(Sis.many(bro__name__any=["Ghost"])), 0)
-
-        # all: tied to a brother named X AND a brother named Y (distinct names)
-        self.assertEqual(Sis.many(bro__name__all=["Tom", "Dick"]).name, ["Mary"])
-        self.assertEqual(sorted(Sis.many(bro__name__all=["Dick"]).name), ["Ann", "Mary"])
-        self.assertEqual(len(Sis.many(bro__name__all=["Tom", "Harry"])), 0)
-
-        # sibling field operators carry through (case-insensitive substring like)
+        # field operators land on the sibling: in (any of), like (substring)
+        self.assertEqual(sorted(Sis.many(bro__name__in=["Tom", "Harry"]).name), ["Ann", "Mary", "Sue"])
         self.assertEqual(Sis.many(bro__name__like="arr").name, ["Ann"])
 
-        # a list under the default/has operator OR's the values (tied to any of these names)
-        self.assertEqual(sorted(Sis.many(bro__name=["Tom", "Dick"]).name), ["Ann", "Mary", "Sue"])
-        self.assertEqual(sorted(Sis.many(bro__name__has=["Tom", "Dick"]).name), ["Ann", "Mary", "Sue"])
+        # negation is field-level: tied to a brother NOT named Tom (a non-Tom exists), NOT
+        # "not tied to any Tom" -- Mary (Tom, Dick) still matches via Dick
+        self.assertEqual(sorted(Sis.many(bro__name__not_in=["Tom"]).name), ["Ann", "Mary"])
 
-        # a field operator combined with any/all resolves per value (name LIKE om OR LIKE arr)
-        self.assertEqual(sorted(Sis.many(bro__name__like__any=["om", "arr"]).name), ["Ann", "Mary", "Sue"])
-        self.assertEqual(Sis.many(bro__name__like__all=["om", "ick"]).name, ["Mary"])
-
-        # negation
-        self.assertEqual(Sis.many(bro__name__not_has="Tom").name, ["Ann"])
-        self.assertEqual(sorted(Sis.many(bro__name__not_any=["Harry"]).name), ["Mary", "Sue"])
+        # criteria on the same relation filter the SAME tied sibling
+        self.assertEqual(Sis.many(bro__name="Dick", bro__id=harry.id).name, [])
+        self.assertEqual(sorted(Sis.many(bro__name="Dick", bro__id=dick.id).name), ["Ann", "Mary"])
 
         # symmetric: brothers filtered by a tied sister's name
         jane = Sis("Jane").create()
@@ -911,8 +897,7 @@ class TestSource(unittest.TestCase):
         Bro("Bill", sis_id=[jane.id]).create()           # tied to Jane
 
         self.assertEqual(sorted(Bro.many(sis__name="Jane").name), ["Bill", "Bob"])
-        self.assertEqual(Bro.many(sis__name__all=["Jane", "Joan"]).name, ["Bob"])
-        self.assertEqual(Bro.many(sis__name__any=["Joan"]).name, ["Bob"])
+        self.assertEqual(Bro.many(sis__name__in=["Joan"]).name, ["Bob"])
 
     def test_titles_query(self):
 

--- a/test/test_relations/test_unittest.py
+++ b/test/test_relations/test_unittest.py
@@ -859,6 +859,61 @@ class TestSource(unittest.TestCase):
         self.assertEqual(Bro.many(sis_id__all=[jane.id, joan.id]).name, ["Bob"])
         self.assertEqual(Bro.many(sis_id__any=[joan.id]).name, ["Bob"])
 
+    def test_retrieve_ties_attr(self):
+
+        # M2M attribute filtering: filter by a tied sibling's field (bro__name) rather
+        # than its id. has/any/all carry over from tie-id Select, now over the sibling's
+        # attribute values, resolved through the tie table.
+
+        tom = Bro("Tom").create()
+        dick = Bro("Dick").create()
+        harry = Bro("Harry").create()
+
+        Sis("Mary", bro_id=[tom.id, dick.id]).create()   # tied to Tom, Dick
+        Sis("Sue", bro_id=[tom.id]).create()             # tied to Tom
+        Sis("Ann", bro_id=[dick.id, harry.id]).create()  # tied to Dick, Harry
+
+        # has (the default): tied to a brother with that name
+        self.assertEqual(sorted(Sis.many(bro__name="Tom").name), ["Mary", "Sue"])
+        self.assertEqual(Sis.many(bro__name="Harry").name, ["Ann"])
+        self.assertEqual(len(Sis.many(bro__name="Ghost")), 0)
+        self.assertEqual(sorted(Sis.many(bro__name__has="Tom").name), ["Mary", "Sue"])
+
+        # any: tied to a brother whose name is any of these
+        self.assertEqual(sorted(Sis.many(bro__name__any=["Tom", "Harry"]).name), ["Ann", "Mary", "Sue"])
+        self.assertEqual(Sis.many(bro__name__any=["Harry"]).name, ["Ann"])
+        self.assertEqual(len(Sis.many(bro__name__any=["Ghost"])), 0)
+
+        # all: tied to a brother named X AND a brother named Y (distinct names)
+        self.assertEqual(Sis.many(bro__name__all=["Tom", "Dick"]).name, ["Mary"])
+        self.assertEqual(sorted(Sis.many(bro__name__all=["Dick"]).name), ["Ann", "Mary"])
+        self.assertEqual(len(Sis.many(bro__name__all=["Tom", "Harry"])), 0)
+
+        # sibling field operators carry through (case-insensitive substring like)
+        self.assertEqual(Sis.many(bro__name__like="arr").name, ["Ann"])
+
+        # a list under the default/has operator OR's the values (tied to any of these names)
+        self.assertEqual(sorted(Sis.many(bro__name=["Tom", "Dick"]).name), ["Ann", "Mary", "Sue"])
+        self.assertEqual(sorted(Sis.many(bro__name__has=["Tom", "Dick"]).name), ["Ann", "Mary", "Sue"])
+
+        # a field operator combined with any/all resolves per value (name LIKE om OR LIKE arr)
+        self.assertEqual(sorted(Sis.many(bro__name__like__any=["om", "arr"]).name), ["Ann", "Mary", "Sue"])
+        self.assertEqual(Sis.many(bro__name__like__all=["om", "ick"]).name, ["Mary"])
+
+        # negation
+        self.assertEqual(Sis.many(bro__name__not_has="Tom").name, ["Ann"])
+        self.assertEqual(sorted(Sis.many(bro__name__not_any=["Harry"]).name), ["Mary", "Sue"])
+
+        # symmetric: brothers filtered by a tied sister's name
+        jane = Sis("Jane").create()
+        joan = Sis("Joan").create()
+        Bro("Bob", sis_id=[jane.id, joan.id]).create()   # tied to Jane, Joan
+        Bro("Bill", sis_id=[jane.id]).create()           # tied to Jane
+
+        self.assertEqual(sorted(Bro.many(sis__name="Jane").name), ["Bill", "Bob"])
+        self.assertEqual(Bro.many(sis__name__all=["Jane", "Joan"]).name, ["Bob"])
+        self.assertEqual(Bro.many(sis__name__any=["Joan"]).name, ["Bob"])
+
     def test_titles_query(self):
 
         self.assertEqual(self.source.titles_query(None).action, "TITLES")


### PR DESCRIPTION
## M2M attr — sibling-attribute filtering (core)

Adds filtering a model by a tied sibling's field, e.g. `Sis.many(bro__name="Tom")` — "sisters tied to a brother named Tom".

### Semantics — existence
A model matches if it is tied to a sibling satisfying the criteria. The sibling's normal field operators all apply:
- `Sis.many(bro__name="Tom")` — tied to a brother named Tom
- `bro__name__in=["Tom","Dick"]` — tied to a brother named Tom or Dick
- `bro__name__like="T%"`, `bro__name__not_in=[...]`, `bro__name__gt=...`
- Criteria on the same relation filter the **same** tied sibling: `bro__name="Tom", bro__id__gt=5` → one brother that is both.

### Implementation
- `model.filter()` intercepts sibling-accessor paths and groups them per relation into `model._ties = {accessor: {field_predicate: value}}` (`_tie`).
- `Source.attr_ids(relation, side, criteria)` resolves `Sibling.many(**criteria)` → sibling ids → tied model ids; `collate_ties` folds each relation's result into an `id__in` filter — so it works for every backend that uses the core resolver (MockSource, redis).
- SQL backends read `model._ties` and push a flat join (separate PRs).

### Tests
Functional coverage via MockSource (existence, field operators, per-relation grouping, symmetric direction) plus unit tests for capture and resolution. All gates green: build → test (217, 100%) → lint (10.00) → setup.

Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
